### PR TITLE
General: Fix available tokens for staking calculation, indicate when threshold is infinite

### DIFF
--- a/src/components/ConvictionVisuals.js
+++ b/src/components/ConvictionVisuals.js
@@ -57,7 +57,6 @@ export function ConvictionBar({
 
   const secondSize = stakedConviction.minus(userStakedConviction)
   const thirdSize = futureStakedConviction.minus(stakedConviction)
-  console.log(neededConviction.toString())
 
   return (
     <div>

--- a/src/components/ConvictionVisuals.js
+++ b/src/components/ConvictionVisuals.js
@@ -57,6 +57,7 @@ export function ConvictionBar({
 
   const secondSize = stakedConviction.minus(userStakedConviction)
   const thirdSize = futureStakedConviction.minus(stakedConviction)
+  console.log(neededConviction.toString())
 
   return (
     <div>
@@ -83,9 +84,11 @@ export function ConvictionBar({
               `}
             >
               {neededConviction
-                ? `(${Math.round(
-                    neededConviction.multipliedBy(new BigNumber('100'))
-                  )}% Conviction Needed)`
+                ? neededConviction.toString() === '0'
+                  ? '(Infinite conviction needed)'
+                  : `(${Math.round(
+                      neededConviction.multipliedBy(new BigNumber('100'))
+                    )}% Conviction Needed)`
                 : `(&infin; Needed)`}
             </span>
           )}

--- a/src/hooks/useAccountTotalStaked.js
+++ b/src/hooks/useAccountTotalStaked.js
@@ -11,7 +11,11 @@ export default function useAccountTotalStaked() {
   const totalStaked = useMemo(
     () =>
       proposals
-        .filter(({ executed }) => !executed)
+        // NOTE: There can be staked tokens on cancelled or withdrawn proposals,
+        // but the smart contract automatically removes this balance when staking an amount higher
+        // than the available "unstaked" amount.
+        // See: https://github.com/1hive/conviction-voting-app/blob/master/contracts/ConvictionVoting.sol#L489-L508
+        .filter(({ status }) => status !== 'Cancelled' || status !== 'Executed')
         .reduce((acc, { stakes }) => {
           const myStake = stakes.find(({ entity }) =>
             addressesEqual(entity, account)


### PR DESCRIPTION
Fixes the calculation of available tokens for staking, which should not take into account the withdrawn and executed proposal when deducting from the total balance. Also introduces a frontend change to properly indicate when a proposal won't pass because it needs infinite conviction.